### PR TITLE
Add JUnit test for Sort commands

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,8 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 https://travis-ci.org/CS2103AUG2017-W09-B3/main[image:https://travis-ci.org/CS2103AUG2017-W09-B3/main.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
-https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
+https://coveralls.io/github/eldriclim/main?branch=master[image:https://coveralls.io/repos/github/eldriclim/main/badge.svg?branch=master[Coverage Status]]
+https://www.codacy.com/app/eldriclim/main?utm_source=github.com&utm_medium=referral&utm_content=eldriclim/main&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -20,10 +20,12 @@ public class SortCommand extends UndoableCommand {
     public static final String BY_ASCENDING = "asc";
     public static final String BY_DESCENDING = "dsc";
 
-    public static final String MESSAGE_SORT_LIST_SUCCESS = "List has been sorted.";
+    public static final String MESSAGE_SORT_LIST_SUCCESS = "List has been sorted by %1$s in %2$s order.";
     public static final String MESSAGE_MULTIPLE_ATTRIBUTE = "Multiple attributes is not allowed.";
     public static final String MESSAGE_EMPTY_LIST = "The list is empty.";
 
+    private static String sortType_Readable = "name";
+    private static String sortOrder_Readable = "ascending";
 
     private static final String PREFIX_NAME_SORT = "n/";
     private static final String PREFIX_PHONE_SORT = "p/";
@@ -32,6 +34,7 @@ public class SortCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts list of all contacts "
             + "by their various attributes, including ascending and descending order.\n"
+            + "Defaults to sorting by name in ascending order.\n"
             + "Parameters: "
             + "[" + PREFIX_NAME_SORT + "(" + BY_ASCENDING + " OR " + BY_DESCENDING + ")] \n"
             + "Example: " + COMMAND_WORD + " "
@@ -39,6 +42,7 @@ public class SortCommand extends UndoableCommand {
 
     private final String sortType;
     private final Boolean isDescending;
+
 
     /**
      * @param sortType     specify which attribute to sort by
@@ -50,6 +54,8 @@ public class SortCommand extends UndoableCommand {
 
         this.sortType = sortType;
         this.isDescending = isDescending;
+
+        sortOrder_Readable = (isDescending) ? "descending" : "ascending";
     }
 
     @Override
@@ -63,33 +69,39 @@ public class SortCommand extends UndoableCommand {
         }
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_SORT_LIST_SUCCESS));
+        return new CommandResult(String.format(MESSAGE_SORT_LIST_SUCCESS, sortType_Readable, sortOrder_Readable));
     }
 
     public Comparator<ReadOnlyPerson> getComparator(String sortType) {
         switch (sortType) {
         case PREFIX_NAME_SORT:
+            sortType_Readable = "name";
             return (o1, o2) -> o1.getName().toString().compareToIgnoreCase(
                     o2.getName().toString()
             );
         case PREFIX_PHONE_SORT:
+            sortType_Readable = "phone";
             return (o1, o2) -> o1.getPhone().toString().compareToIgnoreCase(
                     o2.getPhone().toString()
             );
         case PREFIX_EMAIL_SORT:
+            sortType_Readable = "email";
             return (o1, o2) -> o1.getEmail().toString().compareToIgnoreCase(
                     o2.getEmail().toString()
             );
         case PREFIX_ADDRESS_SORT:
+            sortType_Readable = "address";
             return (o1, o2) -> o1.getAddress().toString().compareToIgnoreCase(
                     o2.getAddress().toString()
             );
         default:
+            sortType_Readable = "name";
             return (o1, o2) -> o1.getName().toString().compareToIgnoreCase(
                     o2.getName().toString()
             );
         }
     }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -31,13 +31,13 @@ public class SortCommand extends UndoableCommand {
     private static final String PREFIX_EMAIL_SORT = "e/";
     private static final String PREFIX_ADDRESS_SORT = "a/";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts list of all contacts "
-            + "by their various attributes, including ascending and descending order.\n"
-            + "Defaults to sorting by name in ascending order.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts list of all contacts by their attributes,"
+            + " defaults to name when no parameters found and ascending when order not specified.\n"
             + "Parameters: "
             + "[" + PREFIX_NAME_SORT + "(" + BY_ASCENDING + " OR " + BY_DESCENDING + ")] \n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_PHONE_SORT + BY_DESCENDING;
+            + "Example: " + COMMAND_WORD + " " + PREFIX_PHONE_SORT + BY_DESCENDING + " OR "
+            + COMMAND_WORD + " " + PREFIX_ADDRESS_SORT + " OR "
+            + COMMAND_WORD;
 
     private final String sortType;
     private final Boolean isDescending;

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -23,9 +23,6 @@ public class SortCommand extends UndoableCommand {
     public static final String MESSAGE_SORT_LIST_SUCCESS = "List has been sorted by %1$s in %2$s order.";
     public static final String MESSAGE_EMPTY_LIST = "The list is empty.";
 
-    private static String sortTypeReadable = "name";
-    private static String sortOrderReadable = "ascending";
-
     private static final String PREFIX_NAME_SORT = "n/";
     private static final String PREFIX_PHONE_SORT = "p/";
     private static final String PREFIX_EMAIL_SORT = "e/";
@@ -42,12 +39,14 @@ public class SortCommand extends UndoableCommand {
     private final String sortType;
     private final Boolean isDescending;
 
+    private String sortTypeReadable = "name";
+    private String sortOrderReadable = "ascending";
 
     /**
      * @param sortType     specify which attribute to sort by
      * @param isDescending specify if sorting is to be in descending order
      */
-    public SortCommand(String sortType, boolean isDescending) {
+    public SortCommand(String sortType, Boolean isDescending) {
         requireNonNull(sortType);
         requireNonNull(isDescending);
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -38,7 +38,7 @@ public class SortCommand extends UndoableCommand {
             + PREFIX_PHONE_SORT + BY_DESCENDING;
 
     private final String sortType;
-    private final boolean isDescending;
+    private final Boolean isDescending;
 
     /**
      * @param sortType     specify which attribute to sort by
@@ -89,5 +89,13 @@ public class SortCommand extends UndoableCommand {
                     o2.getName().toString()
             );
         }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SortCommand // instanceof handles nulls
+                && sortType.equals(((SortCommand) other).sortType)
+                && isDescending.equals(((SortCommand) other).isDescending));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -66,7 +66,7 @@ public class SortCommand extends UndoableCommand {
         return new CommandResult(String.format(MESSAGE_SORT_LIST_SUCCESS));
     }
 
-    private Comparator<ReadOnlyPerson> getComparator(String sortType) {
+    public Comparator<ReadOnlyPerson> getComparator(String sortType) {
         switch (sortType) {
         case PREFIX_NAME_SORT:
             return (o1, o2) -> o1.getName().toString().compareToIgnoreCase(

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -21,11 +21,10 @@ public class SortCommand extends UndoableCommand {
     public static final String BY_DESCENDING = "dsc";
 
     public static final String MESSAGE_SORT_LIST_SUCCESS = "List has been sorted by %1$s in %2$s order.";
-    public static final String MESSAGE_MULTIPLE_ATTRIBUTE = "Multiple attributes is not allowed.";
     public static final String MESSAGE_EMPTY_LIST = "The list is empty.";
 
-    private static String sortType_Readable = "name";
-    private static String sortOrder_Readable = "ascending";
+    private static String sortTypeReadable = "name";
+    private static String sortOrderReadable = "ascending";
 
     private static final String PREFIX_NAME_SORT = "n/";
     private static final String PREFIX_PHONE_SORT = "p/";
@@ -55,7 +54,7 @@ public class SortCommand extends UndoableCommand {
         this.sortType = sortType;
         this.isDescending = isDescending;
 
-        sortOrder_Readable = (isDescending) ? "descending" : "ascending";
+        sortOrderReadable = (isDescending) ? "descending" : "ascending";
     }
 
     @Override
@@ -69,33 +68,33 @@ public class SortCommand extends UndoableCommand {
         }
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_SORT_LIST_SUCCESS, sortType_Readable, sortOrder_Readable));
+        return new CommandResult(String.format(MESSAGE_SORT_LIST_SUCCESS, sortTypeReadable, sortOrderReadable));
     }
 
     public Comparator<ReadOnlyPerson> getComparator(String sortType) {
         switch (sortType) {
         case PREFIX_NAME_SORT:
-            sortType_Readable = "name";
+            sortTypeReadable = "name";
             return (o1, o2) -> o1.getName().toString().compareToIgnoreCase(
                     o2.getName().toString()
             );
         case PREFIX_PHONE_SORT:
-            sortType_Readable = "phone";
+            sortTypeReadable = "phone";
             return (o1, o2) -> o1.getPhone().toString().compareToIgnoreCase(
                     o2.getPhone().toString()
             );
         case PREFIX_EMAIL_SORT:
-            sortType_Readable = "email";
+            sortTypeReadable = "email";
             return (o1, o2) -> o1.getEmail().toString().compareToIgnoreCase(
                     o2.getEmail().toString()
             );
         case PREFIX_ADDRESS_SORT:
-            sortType_Readable = "address";
+            sortTypeReadable = "address";
             return (o1, o2) -> o1.getAddress().toString().compareToIgnoreCase(
                     o2.getAddress().toString()
             );
         default:
-            sortType_Readable = "name";
+            sortTypeReadable = "name";
             return (o1, o2) -> o1.getName().toString().compareToIgnoreCase(
                     o2.getName().toString()
             );

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -64,7 +64,7 @@ public class SortCommandParser implements Parser<SortCommand> {
                 return;
             }
 
-            if (s.equals("")){
+            if (s.equals("")) {
                 isDescending = new Boolean(false);
                 return;
             }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -76,20 +76,4 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         };
     }
-
-    /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
-     */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws IllegalValueException {
-        assert tags != null;
-
-        if (tags.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -33,7 +33,7 @@ public class SortCommandParser implements Parser<SortCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
-        if (args.equals("")) {
+        if ("".equals(args)) {
             args = " n/asc";
         }
 
@@ -61,7 +61,7 @@ public class SortCommandParser implements Parser<SortCommand> {
             }
 
             //Defaults to ascending when order not specified
-            if (s.equals("")) {
+            if ("".equals(s)) {
                 isDescending = new Boolean(false);
                 return;
             }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -47,10 +47,6 @@ public class SortCommandParser implements Parser<SortCommand> {
         argMultimap.getValue(PREFIX_EMAIL).ifPresent(setSortingOrder(PREFIX_EMAIL));
         argMultimap.getValue(PREFIX_ADDRESS).ifPresent(setSortingOrder(PREFIX_ADDRESS));
 
-        if (isDescending == null) {
-            isDescending = false;
-        }
-
         return new SortCommand(sortType, isDescending);
     }
 
@@ -64,6 +60,7 @@ public class SortCommandParser implements Parser<SortCommand> {
                 return;
             }
 
+            //Defaults to ascending when order not specified
             if (s.equals("")) {
                 isDescending = new Boolean(false);
                 return;

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -28,16 +28,17 @@ public class SortCommandParser implements Parser<SortCommand> {
      */
     public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
-        if (argMultimap.size() > 2) {
-            throw new ParseException(String.format(SortCommand.MESSAGE_MULTIPLE_ATTRIBUTE, SortCommand.MESSAGE_USAGE));
-        }
-
-        if (argMultimap.size() < 2) {
+        if (!args.matches("^|( [npea]/((asc)|(dsc)|))$")) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
+
+        if (args.equals("")) {
+            args = " n/asc";
+        }
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         assert argMultimap.size() == 2;
 
@@ -47,7 +48,7 @@ public class SortCommandParser implements Parser<SortCommand> {
         argMultimap.getValue(PREFIX_ADDRESS).ifPresent(setSortingOrder(PREFIX_ADDRESS));
 
         if (isDescending == null) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+            isDescending = false;
         }
 
         return new SortCommand(sortType, isDescending);
@@ -62,6 +63,12 @@ public class SortCommandParser implements Parser<SortCommand> {
                 isDescending = new Boolean(false);
                 return;
             }
+
+            if (s.equals("")){
+                isDescending = new Boolean(false);
+                return;
+            }
+
             if (s.equals(SortCommand.BY_DESCENDING)) {
                 isDescending = new Boolean(true);
                 return;

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -7,16 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new SortCommand object

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -36,6 +36,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String WHITESPACE = " ";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -86,7 +86,7 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = prepareCommand( personsToDelete1);
+        DeleteCommand deleteCommand = prepareCommand(personsToDelete1);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -120,7 +120,7 @@ public class DeleteCommandTest {
     /**
      * Returns a {@code DeleteCommand} with the parameter {@code index}.
      */
-    private DeleteCommand prepareCommand( ArrayList<Index> indexes) {
+    private DeleteCommand prepareCommand(ArrayList<Index> indexes) {
 
         DeleteCommand deleteCommand = new DeleteCommand(indexes);
         deleteCommand.setData(model, new CommandHistory(), new UndoRedoStack());

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,168 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javafx.collections.ObservableList;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.EmptyListException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.PersonBuilder;
+
+public class SortCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Person validPerson1 = new PersonBuilder()
+            .withName("C").withPhone("465").withEmail("z@z").withAddress("a").build();
+    private Person validPerson2 = new PersonBuilder()
+            .withName("B").withPhone("123").withEmail("d@d").withAddress("s").build();
+    private Person validPerson3 = new PersonBuilder()
+            .withName("A").withPhone("987").withEmail("f@f").withAddress("b").build();
+
+    @Test
+    public void constructor_nullPerson_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new SortCommand(null, new Boolean(null));
+    }
+
+    @Test
+    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonForSort modelStub = new ModelStubAcceptingPersonForSort();
+        populateModel(modelStub);
+
+        CommandResult commandResult = getSortCommandForPerson("n/", false, modelStub).execute();
+
+        assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS), commandResult.feedbackToUser);
+    }
+
+
+    /**
+     * Generates a new AddCommand with the details of the given person.
+     */
+    private AddCommand getAddCommandForPerson(Person person, Model model) {
+        AddCommand command = new AddCommand(person);
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+        return command;
+    }
+
+    /**
+     * Generates a new SortCommand with the details of the given list.
+     */
+    private SortCommand getSortCommandForPerson(String sortType, boolean isDescending, Model model) {
+        SortCommand command = new SortCommand(sortType, isDescending);
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        return command;
+    }
+
+    /**
+     * Populate model list with persons
+     */
+    private void populateModel(Model modelStub) throws Exception {
+        getAddCommandForPerson(validPerson1, modelStub).execute();
+        getAddCommandForPerson(validPerson2, modelStub).execute();
+        getAddCommandForPerson(validPerson3, modelStub).execute();
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void addPerson(ReadOnlyPerson person) throws DuplicatePersonException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void sortPerson(Comparator<ReadOnlyPerson> sortType, boolean isDescending) throws EmptyListException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void resetData(ReadOnlyAddressBook newData) {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public void deletePerson(ReadOnlyPerson target) throws PersonNotFoundException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(ArrayList<ReadOnlyPerson> targets) throws PersonNotFoundException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void updatePerson(ReadOnlyPerson target, ReadOnlyPerson editedPerson)
+                throws DuplicatePersonException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<ReadOnlyPerson> getFilteredPersonList() {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<ReadOnlyPerson> predicate) {
+            fail("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that always accept the person being added and sort list.
+     */
+    private class ModelStubAcceptingPersonForSort extends ModelStub {
+        final ArrayList<Person> personsAdded = new ArrayList<>();
+
+        @Override
+        public void addPerson(ReadOnlyPerson person) throws DuplicatePersonException {
+            personsAdded.add(new Person(person));
+        }
+
+        @Override
+        public void sortPerson(Comparator<ReadOnlyPerson> sortType, boolean isDescending) throws EmptyListException {
+            personsAdded.sort(sortType);
+            if (isDescending) {
+                Collections.reverse(personsAdded);
+            }
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<ReadOnlyPerson> predicate) {
+            return;
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new AddressBook();
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -62,7 +62,8 @@ public class SortCommandTest {
         Boolean isDescending = false;
         CommandResult commandResult = getSortCommandForPerson(sortType, isDescending, modelStub).execute();
 
-        assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS, "name", "ascending"), commandResult.feedbackToUser);
+        assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS, "name", "ascending"),
+                commandResult.feedbackToUser);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -72,18 +72,22 @@ public class SortCommandTest {
         expectedList.add(validPerson2);
         expectedList.add(validPerson3);
 
+        //Test comparator - sort by name
         expectedList.sort((o1, o2) -> o1.getName().toString().compareToIgnoreCase(o2.getName().toString()));
         getSortCommandForPerson("n/", false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
+        //Test comparator - sort by phone
         expectedList.sort((o1, o2) -> o1.getPhone().toString().compareToIgnoreCase(o2.getPhone().toString()));
         getSortCommandForPerson("p/", false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
+        //Test comparator - sort by email
         expectedList.sort((o1, o2) -> o1.getEmail().toString().compareToIgnoreCase(o2.getEmail().toString()));
         getSortCommandForPerson("e/", false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
+        //Test comparator - sort by address
         expectedList.sort((o1, o2) -> o1.getAddress().toString().compareToIgnoreCase(o2.getAddress().toString()));
         getSortCommandForPerson("a/", false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -40,9 +40,15 @@ public class SortCommandTest {
             .withName("A").withPhone("987").withEmail("f@f").withAddress("b").build();
 
     @Test
-    public void constructor_nullPerson_throwsNullPointerException() {
+    public void constructor_nullSortType_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new SortCommand(null, new Boolean(null));
+        new SortCommand(null, true);
+    }
+
+    @Test
+    public void constructor_nullSortOrder_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new SortCommand(CliSyntax.PREFIX_NAME.toString(), null);
     }
 
     @Test
@@ -211,7 +217,7 @@ public class SortCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<ReadOnlyPerson> predicate) {
-            return;
+
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.rules.ExpectedException;
 import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.UndoRedoStack;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -44,6 +45,14 @@ public class SortCommandTest {
     }
 
     @Test
+    public void execute_catchEmptyListException() throws CommandException {
+        thrown.expect(CommandException.class);
+
+        ModelStubAcceptingPersonForSort modelStub = new ModelStubAcceptingPersonForSort();
+        getSortCommandForPerson("n/", false, modelStub).execute();
+    }
+
+    @Test
     public void execute_personAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingPersonForSort modelStub = new ModelStubAcceptingPersonForSort();
         populateModel(modelStub);
@@ -51,6 +60,34 @@ public class SortCommandTest {
         CommandResult commandResult = getSortCommandForPerson("n/", false, modelStub).execute();
 
         assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS), commandResult.feedbackToUser);
+    }
+
+    @Test
+    public void testComparator() throws Exception {
+        ModelStubAcceptingPersonForSort modelStub = new ModelStubAcceptingPersonForSort();
+        populateModel(modelStub);
+
+        ArrayList<Person> expectedList = new ArrayList<>();
+        expectedList.add(validPerson1);
+        expectedList.add(validPerson2);
+        expectedList.add(validPerson3);
+
+        expectedList.sort((o1, o2) -> o1.getName().toString().compareToIgnoreCase(o2.getName().toString()));
+        getSortCommandForPerson("n/", false, modelStub).execute();
+        assertEquals(expectedList, modelStub.personsAdded);
+
+        expectedList.sort((o1, o2) -> o1.getPhone().toString().compareToIgnoreCase(o2.getPhone().toString()));
+        getSortCommandForPerson("p/", false, modelStub).execute();
+        assertEquals(expectedList, modelStub.personsAdded);
+
+        expectedList.sort((o1, o2) -> o1.getEmail().toString().compareToIgnoreCase(o2.getEmail().toString()));
+        getSortCommandForPerson("e/", false, modelStub).execute();
+        assertEquals(expectedList, modelStub.personsAdded);
+
+        expectedList.sort((o1, o2) -> o1.getAddress().toString().compareToIgnoreCase(o2.getAddress().toString()));
+        getSortCommandForPerson("a/", false, modelStub).execute();
+        assertEquals(expectedList, modelStub.personsAdded);
+
     }
 
 
@@ -81,6 +118,7 @@ public class SortCommandTest {
         getAddCommandForPerson(validPerson2, modelStub).execute();
         getAddCommandForPerson(validPerson3, modelStub).execute();
     }
+
 
     /**
      * A default model stub that have all of the methods failing.
@@ -148,6 +186,10 @@ public class SortCommandTest {
 
         @Override
         public void sortPerson(Comparator<ReadOnlyPerson> sortType, boolean isDescending) throws EmptyListException {
+            if (personsAdded.size() < 1) {
+                throw new EmptyListException();
+            }
+
             personsAdded.sort(sortType);
             if (isDescending) {
                 Collections.reverse(personsAdded);
@@ -164,5 +206,6 @@ public class SortCommandTest {
             return new AddressBook();
         }
     }
+
 
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -16,6 +16,7 @@ import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.CliSyntax;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -53,13 +54,15 @@ public class SortCommandTest {
     }
 
     @Test
-    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
+    public void test_getSortCommandResult_sortSuccessful() throws Exception {
         ModelStubAcceptingPersonForSort modelStub = new ModelStubAcceptingPersonForSort();
         populateModel(modelStub);
 
-        CommandResult commandResult = getSortCommandForPerson("n/", false, modelStub).execute();
+        String sortType = "/n";
+        Boolean isDescending = false;
+        CommandResult commandResult = getSortCommandForPerson(sortType, isDescending, modelStub).execute();
 
-        assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS), commandResult.feedbackToUser);
+        assertEquals(String.format(SortCommand.MESSAGE_SORT_LIST_SUCCESS, "name", "ascending"), commandResult.feedbackToUser);
     }
 
     @Test
@@ -74,22 +77,27 @@ public class SortCommandTest {
 
         //Test comparator - sort by name
         expectedList.sort((o1, o2) -> o1.getName().toString().compareToIgnoreCase(o2.getName().toString()));
-        getSortCommandForPerson("n/", false, modelStub).execute();
+        getSortCommandForPerson(CliSyntax.PREFIX_NAME.toString(), false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
         //Test comparator - sort by phone
         expectedList.sort((o1, o2) -> o1.getPhone().toString().compareToIgnoreCase(o2.getPhone().toString()));
-        getSortCommandForPerson("p/", false, modelStub).execute();
+        getSortCommandForPerson(CliSyntax.PREFIX_PHONE.toString(), false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
         //Test comparator - sort by email
         expectedList.sort((o1, o2) -> o1.getEmail().toString().compareToIgnoreCase(o2.getEmail().toString()));
-        getSortCommandForPerson("e/", false, modelStub).execute();
+        getSortCommandForPerson(CliSyntax.PREFIX_EMAIL.toString(), false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
         //Test comparator - sort by address
         expectedList.sort((o1, o2) -> o1.getAddress().toString().compareToIgnoreCase(o2.getAddress().toString()));
-        getSortCommandForPerson("a/", false, modelStub).execute();
+        getSortCommandForPerson(CliSyntax.PREFIX_ADDRESS.toString(), false, modelStub).execute();
+        assertEquals(expectedList, modelStub.personsAdded);
+
+        //Test comparator - sort by address
+        expectedList.sort((o1, o2) -> o1.getName().toString().compareToIgnoreCase(o2.getName().toString()));
+        getSortCommandForPerson("z/", false, modelStub).execute();
         assertEquals(expectedList, modelStub.personsAdded);
 
     }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -25,7 +25,7 @@ public class SortCommandParserTest {
         //More than 1 argument inputted
         assertParseFailure(parser, WHITESPACE + CliSyntax.PREFIX_NAME
                         + SortCommand.BY_ASCENDING + WHITESPACE + CliSyntax.PREFIX_PHONE + SortCommand.BY_ASCENDING,
-        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
         //Gibberish arguments inputted, with one valid argument
         assertParseFailure(parser, WHITESPACE + "gibberish/g" + CliSyntax.PREFIX_PHONE + SortCommand.BY_ASCENDING,

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.WHITESPACE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.commands.SortCommand;
+
+public class SortCommandParserTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_sortOrderNotSpecified_failure() {
+        assertParseFailure(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_notSingleAttribute_failure() {
+
+        //No argument inputted
+        assertParseFailure(parser, SortCommand.COMMAND_WORD,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
+        //No recognised argument inputted
+        assertParseFailure(parser, SortCommand.COMMAND_WORD + "z/" + SortCommand.BY_ASCENDING,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
+        //More than 1 argument inputted
+        assertParseFailure(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME
+                        + SortCommand.BY_ASCENDING + WHITESPACE + CliSyntax.PREFIX_PHONE + SortCommand.BY_ASCENDING,
+                String.format(SortCommand.MESSAGE_MULTIPLE_ATTRIBUTE, SortCommand.MESSAGE_USAGE));
+    }
+
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+
+        assertParseSuccess(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME
+                + SortCommand.BY_ASCENDING, new SortCommand("n/", false));
+
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -19,36 +19,53 @@ public class SortCommandParserTest {
 
     private SortCommandParser parser = new SortCommandParser();
 
-    @Test
-    public void parse_sortOrderNotSpecified_failure() {
-        assertParseFailure(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-    }
 
     @Test
-    public void parse_notSingleAttribute_failure() {
-
-        //No argument inputted
-        assertParseFailure(parser, SortCommand.COMMAND_WORD,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-
-        //No recognised argument inputted
-        assertParseFailure(parser, SortCommand.COMMAND_WORD + "z/" + SortCommand.BY_ASCENDING,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-
+    public void parseFailure() {
         //More than 1 argument inputted
-        assertParseFailure(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME
+        assertParseFailure(parser, WHITESPACE + CliSyntax.PREFIX_NAME
                         + SortCommand.BY_ASCENDING + WHITESPACE + CliSyntax.PREFIX_PHONE + SortCommand.BY_ASCENDING,
-                String.format(SortCommand.MESSAGE_MULTIPLE_ATTRIBUTE, SortCommand.MESSAGE_USAGE));
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
+        //Gibberish arguments inputted, with one valid argument
+        assertParseFailure(parser, WHITESPACE + "gibberish/g" + CliSyntax.PREFIX_PHONE + SortCommand.BY_ASCENDING,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
+        //Sort order not recognised
+        assertParseFailure(parser, WHITESPACE + CliSyntax.PREFIX_PHONE + "gibberish",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }
 
 
     @Test
-    public void parse_allFieldsPresent_success() {
+    public void parseSuccess() {
 
-        assertParseSuccess(parser, SortCommand.COMMAND_WORD + WHITESPACE + CliSyntax.PREFIX_NAME
+        assertParseSuccess(parser, "", new SortCommand("n/", false));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_NAME
                 + SortCommand.BY_ASCENDING, new SortCommand("n/", false));
 
-    }
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_PHONE
+                + SortCommand.BY_ASCENDING, new SortCommand("p/", false));
 
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_EMAIL
+                + SortCommand.BY_ASCENDING, new SortCommand("e/", false));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_ADDRESS
+                + SortCommand.BY_ASCENDING, new SortCommand("a/", false));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_NAME
+                + SortCommand.BY_DESCENDING, new SortCommand("n/", true));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_PHONE
+                + SortCommand.BY_DESCENDING, new SortCommand("p/", true));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_EMAIL
+                + SortCommand.BY_DESCENDING, new SortCommand("e/", true));
+
+        assertParseSuccess(parser, WHITESPACE + CliSyntax.PREFIX_ADDRESS
+                + SortCommand.BY_DESCENDING, new SortCommand("a/", true));
+
+
+    }
 }


### PR DESCRIPTION
Added JUnit test for all sort related classes.
SortCommandParser now uses regex to verify inputs.
Possible Codacy issues for "Method names should not contain underscores". 
(ignored to remain consistent with past implementations in AB4)